### PR TITLE
edit(notifications) Notifications moved down if bodycam on

### DIFF
--- a/resources/[mythic]/mythic-hud/client/hud.lua
+++ b/resources/[mythic]/mythic-hud/client/hud.lua
@@ -459,6 +459,15 @@ AddEventHandler("Proxy:Shared:RegisterReady", function()
 	exports["mythic-base"]:RegisterComponent("Hud", HUD)
 end)
 
+AddEventHandler("HUD:Client:BodycamToggled", function(state)
+	SendNUIMessage({
+		type = "BODYCAM_TOGGLED",
+		data = {
+			state = state
+		}
+	})
+end)
+
 function GetLocation()
 	local pos = GetEntityCoords(LocalPlayer.state.ped)
 

--- a/resources/[mythic]/mythic-hud/ui/src/containers/App/reducer.js
+++ b/resources/[mythic]/mythic-hud/ui/src/containers/App/reducer.js
@@ -15,6 +15,8 @@ export const initialState = {
     releaseKey: false,
     helpKey: false,
     medicalPrice: false,
+
+    bodycamActive: false,
 };
 
 const appReducer = (state = initialState, action) => {
@@ -89,6 +91,12 @@ const appReducer = (state = initialState, action) => {
                 ...state,
                 flashbanged: false,
             };
+        case 'BODYCAM_TOGGLED': {
+            return {
+                ...state,
+                bodycamActive: action.payload.state
+            }
+        }
         default:
             return state;
     }

--- a/resources/[mythic]/mythic-hud/ui/src/containers/Notifications/index.jsx
+++ b/resources/[mythic]/mythic-hud/ui/src/containers/Notifications/index.jsx
@@ -12,12 +12,12 @@ const useStyles = makeStyles((theme) => ({
         position: 'absolute',
         padding: 10,
         right: 0,
-        top: 0,
     },
 }));
 
 export default () => {
     const classes = useStyles();
+    const bodyCamActive = useSelector((state) => state.app.bodycamActive);
 
     const pers = useSelector((state) =>
         state.notification.notifications.filter((n) => n.duration <= 0),
@@ -27,7 +27,7 @@ export default () => {
     );
 
     return (
-        <div className={classes.wrapper}>
+        <div className={classes.wrapper} style={{top: bodyCamActive? '13vh' : 0}}>
             {pers.length > 0 &&
                 pers
                     .sort((a, b) => b.created - a.created)

--- a/resources/[mythic]/mythic-mdt/client/client.lua
+++ b/resources/[mythic]/mythic-mdt/client/client.lua
@@ -163,6 +163,7 @@ AddEventHandler("MDT:Client:ToggleBodyCam", function()
 	})
 
 	_bodycam = not _bodycam
+	TriggerEvent("HUD:Client:BodycamToggled", _bodycam)
 	if _bodycam then
 		Sounds.Play:Distance(15, "bodycam.ogg", 0.05)
 	end


### PR DESCRIPTION
When the bodycam is active notifications will down be moved down, so they're no longer overlapping each other.